### PR TITLE
compile with rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
     trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
-    unused_extern_crates,
     unused_import_braces,
     unused_qualifications
 )]
@@ -41,8 +40,6 @@
 //! ```
 //!
 //! This attribute does not use or generate any unsafe code.
-
-extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;


### PR DESCRIPTION
rust nightly errors out that the lint is already part of the rust_2018_idioms:

```
error[E0453]: warn(unused_extern_crates) incompatible with previous forbid in same scope
  --> /Users/ember/.cargo/registry/src/github.com-1ecc6299db9ec823/atomic_enum-0.1.1/src/lib.rs:13:5
   |
2  |     rust_2018_idioms,
   |     ---------------- `forbid` level set here
...
13 |     unused_extern_crates,
   |     ^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error
```