### PR TITLE
Add README, Rust 2021, Remove deprecated features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
-name = "atomic_enum"
-version = "0.2.0"
-authors = ["Thomas Bächler <thomas@archlinux.org>"]
+name = "atomic_enum_2021"
+version = "0.1.0"
+authors = ["Thomas Bächler <thomas@archlinux.org>", "l1npengtul <l1npengtul@protonmail.com>"]
 edition = "2021"
-description = "An attribute to create an atomic wrapper around a C-style enum"
-repository = "https://github.com/brain0/atomic_enum"
+description = "An attribute to create an atomic wrapper around a C-style enum, forked for Rust 2021"
+repository = "https://github.com/l1npengtul/atomic_enum"
 keywords = ["atomic", "enum"]
 categories = ["concurrency"]
 license = "MIT"
-
-[badges]
-maintenance = { status = "passively-maintained" }
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "atomic_enum"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Thomas Bächler <thomas@archlinux.org>"]
-edition = "2018"
-
+edition = "2021"
 description = "An attribute to create an atomic wrapper around a C-style enum"
 repository = "https://github.com/brain0/atomic_enum"
 keywords = ["atomic", "enum"]
@@ -17,6 +16,6 @@ maintenance = { status = "passively-maintained" }
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.16", features = ["full"] }
-quote = "1.0.3"
-proc-macro2 = "1.0.9"
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Thomas Bächler <thomas@archlinux.org>", "l1npengtul <l1npengtul@protonmail.com>"]
 edition = "2021"
 description = "An attribute to create an atomic wrapper around a C-style enum, forked for Rust 2021"
-repository = "https://github.com/l1npengtul/atomic_enum"
-keywords = ["atomic", "enum"]
+repository = "https://github.com/l1npengtul/atomic_enum_2021"
+keywords = ["atomic", "enum", "2021"]
 categories = ["concurrency"]
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![cargo version](https://img.shields.io/crates/v/atomic_enum_2021.svg)](https://crates.io/crates/atomic_enum) 
+[![cargo version](https://img.shields.io/crates/v/atomic_enum_2021.svg)](https://crates.io/crates/atomic_enum_2021) 
 [![docs.rs version](https://img.shields.io/docsrs/atomic_enum_2021)](https://docs.rs/atomic_enum_2021/latest/atomic_enum_2021/)
 # atomic_enum_2021
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+[![cargo version](https://img.shields.io/crates/v/atomic_enum.svg)](https://crates.io/crates/atomic_enum) 
+[![docs.rs version](https://img.shields.io/docsrs/atomic_enum)](https://docs.rs/atomic_enum/latest/atomic_enum/)
+# atomic_enum
+
+ An attribute to create an atomic wrapper around a C-style enum.
+
+ Internally, the generated wrapper uses an `AtomicUsize` to store the value.
+ The atomic operations have the same semantics as the equivalent operations
+ of `AtomicUsize`.
+
+ # Example
+ ```
+ # use atomic_enum::atomic_enum;
+ # use std::sync::atomic::Ordering;
+ #[atomic_enum]
+ #[derive(PartialEq)]
+ enum CatState {
+     Dead = 0,
+     BothDeadAndAlive,
+     Alive,
+ }
+
+ let state = AtomicCatState::new(CatState::Dead);
+ state.store(CatState::Alive, Ordering::Relaxed);
+
+ assert_eq!(state.load(Ordering::Relaxed), CatState::Alive);
+ ```
+
+ This attribute does not use or generate any unsafe code.
+
+# Maintenance Note
+This crate is passively maintained.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-[![cargo version](https://img.shields.io/crates/v/atomic_enum.svg)](https://crates.io/crates/atomic_enum) 
-[![docs.rs version](https://img.shields.io/docsrs/atomic_enum)](https://docs.rs/atomic_enum/latest/atomic_enum/)
-# atomic_enum
+[![cargo version](https://img.shields.io/crates/v/atomic_enum_2021.svg)](https://crates.io/crates/atomic_enum) 
+[![docs.rs version](https://img.shields.io/docsrs/atomic_enum_2021)](https://docs.rs/atomic_enum_2021/latest/atomic_enum_2021/)
+# atomic_enum_2021
 
  An attribute to create an atomic wrapper around a C-style enum.
 
  Internally, the generated wrapper uses an `AtomicUsize` to store the value.
  The atomic operations have the same semantics as the equivalent operations
  of `AtomicUsize`.
+
+Forked and maintained by `l1npengtul` to remove warnings when compiling for modern versions of Rust.  
 
  # Example
  ```
@@ -28,5 +30,5 @@
 
  This attribute does not use or generate any unsafe code.
 
-# Maintenance Note
-This crate is passively maintained.
+# MSRV
+Rust 2021 Edition (1.56)


### PR DESCRIPTION
Thank you for making this! 

Changelist:
- Bumped dependencies, taking advantage of semver to automatically update them.
- Added a README. 
- Bumped to rust 2021.
- Use clippy lints.
- Removed `atomic_enum_compare_and_swap` as it causes deprecation warnings on newer versions of rust (>1.50)