### PR TITLE
Create CAS feature for better no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ license = "MIT"
 [badges]
 maintenance = { status = "passively-maintained" }
 
+[features]
+default = ["cas"]
+cas = [] # enables compare-and-swap operations on atomics
+
 [lib]
 proc-macro = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,7 @@ fn atomic_enum_store(ident: &Ident) -> TokenStream2 {
 }
 
 fn atomic_enum_swap(ident: &Ident) -> TokenStream2 {
+    #[cfg(cas)]
     quote! {
         /// Stores a value into the atomic, returning the previous value.
         ///
@@ -224,9 +225,12 @@ fn atomic_enum_swap(ident: &Ident) -> TokenStream2 {
             Self::from_usize(self.0.swap(Self::to_usize(val), order))
         }
     }
+    #[cfg(not(cas))]
+    TokenStream2::new()
 }
 
 fn atomic_enum_compare_and_swap(ident: &Ident) -> TokenStream2 {
+    #[cfg(cas)]
     quote! {
         /// Stores a value into the atomic if the current value is the same as the `current` value.
         ///
@@ -251,9 +255,12 @@ fn atomic_enum_compare_and_swap(ident: &Ident) -> TokenStream2 {
             ))
         }
     }
+    #[cfg(not(cas))]
+    TokenStream2::new()
 }
 
 fn atomic_enum_compare_exchange(ident: &Ident) -> TokenStream2 {
+    #[cfg(cas)]
     quote! {
         /// Stores a value into the atomic if the current value is the same as the `current` value.
         ///
@@ -283,9 +290,12 @@ fn atomic_enum_compare_exchange(ident: &Ident) -> TokenStream2 {
                 .map_err(Self::from_usize)
         }
     }
+    #[cfg(not(cas))]
+    TokenStream2::new()
 }
 
 fn atomic_enum_compare_exchange_weak(ident: &Ident) -> TokenStream2 {
+    #[cfg(cas)]
     quote! {
         /// Stores a value into the atomic if the current value is the same as the `current` value.
         ///
@@ -316,6 +326,8 @@ fn atomic_enum_compare_exchange_weak(ident: &Ident) -> TokenStream2 {
                 .map_err(Self::from_usize)
         }
     }
+    #[cfg(not(cas))]
+    TokenStream2::new()
 }
 
 fn from_impl(ident: &Ident, atomic_ident: &Ident) -> TokenStream2 {

--- a/tests/nostd.rs
+++ b/tests/nostd.rs
@@ -14,12 +14,36 @@ enum FooBar {
     Bar,
 }
 
+#[cfg(feature = "cas")]
 #[test]
 fn test_no_std_use() {
     let fb = AtomicFooBar::new(FooBar::Foo);
-    let prev = fb.compare_exchange(FooBar::Foo, FooBar::Bar, Ordering::SeqCst, Ordering::Relaxed).unwrap();
+    let prev = fb
+        .compare_exchange(
+            FooBar::Foo,
+            FooBar::Bar,
+            Ordering::SeqCst,
+            Ordering::Relaxed,
+        )
+        .unwrap();
     assert_eq!(prev, FooBar::Foo);
 
-    let prev_fail = fb.compare_exchange(FooBar::Foo, FooBar::Bar, Ordering::SeqCst, Ordering::Relaxed);
+    let prev_fail = fb.compare_exchange(
+        FooBar::Foo,
+        FooBar::Bar,
+        Ordering::SeqCst,
+        Ordering::Relaxed,
+    );
     assert!(prev_fail.is_err());
+}
+
+#[test]
+fn test_load_store() {
+    let original = FooBar::Foo;
+    let fb = AtomicFooBar::new(original);
+    assert_eq!(fb.load(Ordering::SeqCst), original);
+
+    let new = FooBar::Bar;
+    fb.store(new, Ordering::SeqCst);
+    assert_eq!(fb.load(Ordering::SeqCst), new);
 }


### PR DESCRIPTION
Many popular embedded microcontrollers don't support atomic compare-and-swap operations, such as the esp32c3. This PR introduces a feature flag for CAS, so that libraries that don't need the CAS operations can opt-out.

Note that this is technically a breaking change.