### PR TITLE
support enum with Display trait implemented

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ fn debug_impl(atomic_ident: &Ident) -> TokenStream2 {
     quote! {
         impl core::fmt::Debug for #atomic_ident {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                self.load(core::sync::atomic::Ordering::SeqCst).fmt(f)
+                core::fmt::Debug::fmt(&self.load(core::sync::atomic::Ordering::SeqCst), f)
             }
         }
     }

--- a/tests/with_display.rs
+++ b/tests/with_display.rs
@@ -1,0 +1,25 @@
+use core::sync::atomic::Ordering;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
+use atomic_enum::atomic_enum;
+
+#[atomic_enum]
+#[derive(PartialEq, Eq)]
+enum DisplayableEnum {
+    Foo,
+}
+
+impl Display for DisplayableEnum {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            DisplayableEnum::Foo => write!(f, "Foo"),
+        }
+    }
+}
+
+#[test]
+fn test_displayable_enum() {
+    let e = AtomicDisplayableEnum::new(DisplayableEnum::Foo);
+    assert_eq!(format!("{}", e.load(Ordering::SeqCst)), "Foo");
+}


### PR DESCRIPTION
Fix errors when enum has Display trait implemented
```
error[E0034]: multiple applicable items in scope
  --> tests/with_display.rs:7:1
   |
7  | #[atomic_enum]
   | ^^^^^^^^^^^^^^ multiple `fmt` found
   |
note: candidate #1 is defined in an impl of the trait `std::fmt::Display` for the type `DisplayableEnum`
  --> tests/with_display.rs:14:5
   |
14 |     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: candidate #2 is defined in an impl of the trait `Debug` for the type `DisplayableEnum`
  --> tests/with_display.rs:7:1
   |
7  | #[atomic_enum]
   | ^^^^^^^^^^^^^^
   = note: this error originates in the attribute macro `atomic_enum` which comes from the expansion of the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
help: disambiguate the method for candidate #1
   |
7  | std::fmt::Display::fmt(&#[atomic_enum], #[atomic_enum])
   |
help: disambiguate the method for candidate #2
   |
7  | Debug::fmt(&#[atomic_enum], #[atomic_enum])
   |

error: aborting due to 1 previous error
```