### PR TITLE
Fix the build for enums that have cfg-gated elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,20 +93,19 @@ fn enum_to_usize(ident: &Ident) -> TokenStream2 {
 fn enum_from_usize(ident: &Ident, variants: impl IntoIterator<Item = Variant>) -> TokenStream2 {
     let variants_with_const_names: Vec<_> = variants
         .into_iter()
-        .map(|v| v.ident)
-        .map(|id| {
-            let c_id = Ident::new(&format!("USIZE_{}", &id), id.span());
-            (id, c_id)
+        .map(|v| {
+            let c_id = Ident::new(&format!("USIZE_{}", &v.ident), v.ident.span());
+            (v.attrs, v.ident, c_id)
         })
         .collect();
 
     let variant_consts = variants_with_const_names
         .iter()
-        .map(|(id, c_id)| quote! { const #c_id: usize = #ident::#id as usize; });
+        .map(|(attrs, id, c_id)| quote! { #(#attrs)* const #c_id: usize = #ident::#id as usize; });
 
     let variants_back = variants_with_const_names
         .iter()
-        .map(|(id, c_id)| quote! { #c_id => #ident::#id, });
+        .map(|(attrs, id, c_id)| quote! { #(#attrs)* #c_id => #ident::#id, });
 
     quote! {
         fn from_usize(val: usize) -> #ident {

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -1,0 +1,20 @@
+#![allow(unexpected_cfgs)] // multics is deliberately always false
+
+use atomic_enum::atomic_enum;
+
+#[atomic_enum]
+enum MyEnum {
+    Foo,
+    #[cfg(target_os = "multics")]
+    Bar,
+    #[cfg(not(target_os = "multics"))]
+    Baz
+}
+
+// Foo and Baz should both be constructible.  Bar should not be, but that can only be verified from
+// a doc test.
+#[test]
+fn construction() {
+    let _ = AtomicMyEnum::new(MyEnum::Foo);
+    let _ = AtomicMyEnum::new(MyEnum::Baz);
+}


### PR DESCRIPTION
The cfg-gates must be propagated every place that the element is used in the generated code.

Fixes #10